### PR TITLE
Detect cases of duplicate entries of cities/towns

### DIFF
--- a/wikidata_query_service.js
+++ b/wikidata_query_service.js
@@ -71,10 +71,9 @@ async function queryWikidata(query) {
     if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
     }
-
+    console.log(`====================\n${query}\n====================`);
     const data = await response.json();
     return data.results.bindings;
-
 }
 
 async function getCitiesAndTownsInStateRelation(relationId) {


### PR DESCRIPTION
Detects duplicate entries of cities/towns in cases where the number of cities/towns with a certain name in wikidata doesn't match the number of cities/towns with that name in OSM.