### PR TITLE
Add former boundaries to exclude list

### DIFF
--- a/non_admin_entities.js
+++ b/non_admin_entities.js
@@ -5,6 +5,7 @@ function nonAdminQIDs() {
         'Q5398059',  // US Indian reservation
         'Q35080211', // US Wildlife manag
         'Q15726209', // US school district
+        'Q131463097', // former municipality
     ];
 }
 


### PR DESCRIPTION
Former municipalities should be made an instance of Q131463097 and they'll be properly excluded.