### PR TITLE
Add checks for official name, short name

### DIFF
--- a/bounds_to_csv.js
+++ b/bounds_to_csv.js
@@ -7,7 +7,7 @@ async function saveBoundariesWithinToCSV(osmRelationID) {
     console.log(`Query overpass for boundaries within r${osmRelationID}`);
     const overpassUrl = 'http://overpass-api.de/api/interpreter';
     const relationid = Number(osmRelationID) + 3600000000;
-    const query = `[timeout:180][out:csv(::id,::type,type,wikidata,wikipedia,admin_level,boundary,name,"name:en",fixme,alt_name,place,border_type;true;',')];
+    const query = `[timeout:180][out:csv(::id,::type,type,wikidata,wikipedia,admin_level,boundary,name,"name:en",fixme,alt_name,official_name,short_name,place,border_type;true;',')];
         area(id:${relationid})->.a;
         (
           rel[boundary=administrative][admin_level~"^7|8|9$"](area.a);


### PR DESCRIPTION
Adds the following behavior:
* Ensures that `official_name` matches the corresponding wikidata property, if either are present
* Same with `short_name`
* Treats the wikidata "official name" property as an alias for the purpose of name matching with OSM.