### PR TITLE
Include all admin_level=6 boundaries with "city" in the border_type

### DIFF
--- a/bounds_to_csv.js
+++ b/bounds_to_csv.js
@@ -10,6 +10,7 @@ async function saveBoundariesWithinToCSV(osmRelationID) {
         area(id:${relationid})->.a;
         (
           rel[boundary=administrative][admin_level~"^7|8|9$"](area.a);
+          rel[boundary=administrative][admin_level=6][border_type~city](area.a);
           way[boundary=administrative][admin_level~"^7|8|9$"](if:is_closed())(area.a);
           rel[boundary=census][border_type!=unorganized_territory](area.a);
           rel[type=boundary][!boundary](area.a);


### PR DESCRIPTION
This add handling for CCCs and ICs which might be at admin_level=6 but but still be a city-level boundary.  It requires that `border_type` contain the word "city" somewhere in it.  This covers ICs (`border_type=city`) as well as CCCs (`border_type=county;city`)