### PR TITLE
Flag an error if an admin_centre role is present on a relation

### DIFF
--- a/wikidata_boundary_check.js
+++ b/wikidata_boundary_check.js
@@ -657,6 +657,9 @@ async function processCSV(results, writers, state, censusPlaces, citiesAndTowns)
                     }
                 }
             }
+            if (processedRow.count_admin_centre > 0) {
+                flags.push(`Relation has an admin_centre member, which is incorrect for a municipality`);
+            }
             if (CDP_QID.some(qid => processedRow.P31.includes(qid)) && processedRow.boundary == "administrative") {
                 flags.push("Wikidata says CDP/unincorporated, OSM says admin boundary");
             }


### PR DESCRIPTION
Unless someone can find an instance of a neighborhood being the capital of a city, `admin_centre` roles are always an error on a municipality.  Flag this as an error.