### PR TITLE
Add utility to remove all relation members matching a specific role

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ out skel qt;
 To find boundary relations that have both a label and a (redundant) place node, use the following JOSM query examples (Ctrl+F to find it):
 
 ```
-type:relation boundary=census place=* hasRole:label
-type:relation boundary=administrative admin_level=8 place=* hasRole:label
+type:relation boundary=* place=* hasRole:label parent place=*
 ```
 
 ## Scripts
 
 - `admin2label.js` - Change admin_centre relation roles to label. Command line argument is the path to an OSM file.
 - `tagspark.js` - Copies values from a specified Wikidata property to a specified OSM tag. Takes an OSM file path, a Wikidata property ID, and an OSM tag key as arguments.
+- `rolepurge.js` - Removes relation members with a specified role. Takes an OSM file path and role name as arguments.

--- a/rolepurge.js
+++ b/rolepurge.js
@@ -1,0 +1,65 @@
+const fs = require('fs');
+const xml2js = require('xml2js');
+
+// Load and parse the OSM file
+const osmFilePath = process.argv[2];
+const roleToRemove = process.argv[3];
+
+if (!osmFilePath || !roleToRemove) {
+    console.error('Usage: node roleclear.js <osm-file> <role-to-remove>');
+    process.exit(1);
+}
+
+fs.readFile(osmFilePath, 'utf8', (err, data) => {
+    if (err) {
+        console.error('Error reading OSM file:', err);
+        return;
+    }
+
+    const parser = new xml2js.Parser();
+    parser.parseString(data, (parseErr, result) => {
+        if (parseErr) {
+            console.error('Error parsing OSM file:', parseErr);
+            return;
+        }
+
+        let modified = false;
+
+        // Iterate through relations
+        const relations = result.osm.relation || [];
+        relations.forEach((relation) => {
+            const members = relation.member || [];
+            const originalLength = members.length;
+
+            // Remove members with matching role
+            const newMembers = members.filter(member => member.$.role !== roleToRemove);
+
+            if (newMembers.length < originalLength) {
+                relation.member = newMembers;
+                
+                // Add action="modify" to the relation
+                if (!relation.$.action) {
+                    relation.$.action = 'modify';
+                }
+                
+                modified = true;
+            }
+        });
+
+        if (modified) {
+            const builder = new xml2js.Builder({ headless: true });
+            const updatedXml = builder.buildObject(result);
+
+            // Write the modified data back to the OSM file
+            fs.writeFile(osmFilePath, updatedXml, (writeErr) => {
+                if (writeErr) {
+                    console.error('Error writing updated OSM file:', writeErr);
+                } else {
+                    console.log('OSM file updated successfully.');
+                }
+            });
+        } else {
+            console.log('No modifications were necessary.');
+        }
+    });
+});


### PR DESCRIPTION
For example, this command will remove all subarea members from a .osm file:

```
node rolepurge.js file.osm subarea
```
