### PR TITLE
Add boundary=statistical to CDP checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To download boundary and place node data for a state, use the following overpass
 [out:json][timeout:300];
 area["boundary"="administrative"]["name"="NAME_OF_STATE"]["admin_level"=4]->.searchArea;
 (
-  nwr["boundary"~"^census|administrative$"](area.searchArea);
+  nwr["boundary"~"^census|administrative|statistical$"](area.searchArea);
   rel[type=boundary][admin_level](area.searchArea);
   rel[type=boundary][boundary=place](area.searchArea);
   node[place](area.searchArea);

--- a/bounds_to_csv.js
+++ b/bounds_to_csv.js
@@ -12,7 +12,8 @@ area(id:${relationid})->.a;
 (
   rel[boundary=administrative][admin_level~"^7|8|9$"](area.a);
   rel[boundary=administrative][admin_level=6][border_type~city](area.a);
-  rel[boundary=census][border_type!=unorganized_territory](area.a);
+  rel[boundary=census](area.a);
+  rel[boundary=statistical][border_type=census_designated_place](area.a);
   rel[type=boundary][!boundary](area.a);
 );
 


### PR DESCRIPTION
With this change, the following are treated as accepted tagging for CDPs:
* `boundary=census`
* `boundary=statistical` + `border_type=census_designated_place`