### PR TITLE
Add utility to attach labels to existing place name

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Link: https://zelonewolf.github.io/wikidata-qa
 ## Downloading boundary and place node data for a state
 
 To download boundary and place node data for a state, use the following overpass query in JOSM:
-
 ```
 [out:json][timeout:300];
 area["boundary"="administrative"]["name"="NAME_OF_STATE"]["admin_level"=4]->.searchArea;
@@ -36,9 +35,9 @@ To find boundary relations that have both a label and a (redundant) place node, 
 ```
 type:relation boundary=* place=* hasRole:label parent place=*
 ```
-
 ## Scripts
 - `admin2label.js` - Change admin_centre relation roles to label. Command line argument is the path to an OSM file.
+- `label_attach.js` - Attaches place nodes as label members to matching boundary relations where there is a 1:1 name match. Takes an OSM file path as argument.
 - `propspark.js` - Generates QuickStatements CSV file to add property values to Wikidata items based on OSM tags. Takes an OSM file path, source tag key, and Wikidata property ID as arguments.
 - `rolepurge.js` - Removes relation members with a specified role. Takes an OSM file path and role name as arguments.
 - `tagspark.js` - Copies values from a specified Wikidata property to a specified OSM tag. Takes an OSM file path, a Wikidata property ID, and an OSM tag key as arguments.

--- a/label_attach.js
+++ b/label_attach.js
@@ -1,0 +1,123 @@
+const fs = require('fs');
+const xml2js = require('xml2js');
+
+// Load and parse the OSM file
+const osmFilePath = process.argv[2];
+
+if (!osmFilePath) {
+    console.error('Usage: node label_attach.js <osm-file>');
+    process.exit(1); 
+}
+
+fs.readFile(osmFilePath, 'utf8', (err, data) => {
+    if (err) {
+        console.error('Error reading OSM file:', err);
+        return;
+    }
+
+    const parser = new xml2js.Parser();
+    parser.parseString(data, (parseErr, result) => {
+        if (parseErr) {
+            console.error('Error parsing OSM file:', parseErr);
+            return;
+        }
+
+        let modified = false;
+        let updateCount = 0;
+
+        // Get all nodes with place tag
+        const placeNodes = (result.osm.node || []).filter(node => {
+            const tags = node.tag || [];
+            return tags.some(tag => tag.$.k === 'place');
+        });
+
+        // Create map of place node names to nodes
+        const placeNodesByName = new Map();
+        placeNodes.forEach(node => {
+            const tags = node.tag || [];
+            const nameTag = tags.find(tag => tag.$.k === 'name');
+            if (nameTag) {
+                const name = nameTag.$.v;
+                if (!placeNodesByName.has(name)) {
+                    placeNodesByName.set(name, []);
+                }
+                placeNodesByName.get(name).push(node);
+            }
+        });
+
+        // Get boundary relations without admin_centre or label
+        const relations = (result.osm.relation || []).filter(relation => {
+            const tags = relation.tag || [];
+            const members = relation.member || [];
+            const isBoundary = tags.some(tag => tag.$.k === 'boundary');
+            const hasAdminCentre = members.some(member => member.$.role === 'admin_centre');
+            const hasLabel = members.some(member => member.$.role === 'label');
+            return isBoundary && !hasAdminCentre && !hasLabel;
+        });
+
+        // Create map of relation names to relations
+        const relationsByName = new Map();
+        relations.forEach(relation => {
+            const tags = relation.tag || [];
+            const nameTag = tags.find(tag => tag.$.k === 'name');
+            if (nameTag) {
+                const name = nameTag.$.v;
+                if (!relationsByName.has(name)) {
+                    relationsByName.set(name, []);
+                }
+                relationsByName.get(name).push(relation);
+            }
+        });
+
+        // Find 1:1 matches and attach labels
+        for (const [name, nodes] of placeNodesByName) {
+            const matchingRelations = relationsByName.get(name) || [];
+            
+            if (nodes.length === 1 && matchingRelations.length === 1) {
+                const node = nodes[0];
+                const relation = matchingRelations[0];
+
+                // Add node as label member
+                if (!relation.member) {
+                    relation.member = [];
+                }
+                relation.member.push({
+                    $: {
+                        type: 'node',
+                        ref: node.$.id,
+                        role: 'label'
+                    }
+                });
+
+                // Remove place tag from relation if present
+                const tags = relation.tag || [];
+                relation.tag = tags.filter(tag => tag.$.k !== 'place');
+
+                // Mark relation as modified
+                if (!relation.$.action) {
+                    relation.$.action = 'modify';
+                }
+
+                modified = true;
+                updateCount++;
+                console.log(`Added label to boundary ${name} (relation ${relation.$.id})`);
+            }
+        }
+
+        if (modified) {
+            const builder = new xml2js.Builder({ headless: true });
+            const updatedXml = builder.buildObject(result);
+
+            // Write the modified data back to the OSM file
+            fs.writeFile(osmFilePath, updatedXml, (writeErr) => {
+                if (writeErr) {
+                    console.error('Error writing updated OSM file:', writeErr);
+                } else {
+                    console.log(`OSM file updated successfully. Modified ${updateCount} boundaries.`);
+                }
+            });
+        } else {
+            console.log('No modifications were necessary.');
+        }
+    });
+});


### PR DESCRIPTION
Usage:
`node label_attach.js file.osm`

This utility accepts an OSM file with place=* nodes and boundary relations.  For all cases where there is exactly one place node and one boundary relation with the same name, this utility attaches the place node to the boundary relation with role "label", and removes the "place" tag from the boundary relation in one maneuver.  The OSM file can then be opened in JOSM and uploaded.