### PR TITLE
Prevent paper fictions in wikidata from being counted as a boundary

### DIFF
--- a/non_admin_entities.js
+++ b/non_admin_entities.js
@@ -6,6 +6,7 @@ function nonAdminQIDs() {
         'Q35080211', // US Wildlife manag
         'Q15726209', // US school district
         'Q131463097', // former municipality
+        'Q931483', // legal fiction
     ];
 }
 


### PR DESCRIPTION
Adds https://www.wikidata.org/wiki/Q931483 to the exclude list